### PR TITLE
added updates on QAdmin and contract addresses

### DIFF
--- a/docs/contract-addresses.md
+++ b/docs/contract-addresses.md
@@ -10,11 +10,11 @@
 
 | Contract | Address |
 | -------- | ------- |
-| QuotePublisher | [0xe966a3F19527f9Ba719ea832186cA901f0117150](https://moonbase.moonscan.io/address/0xe966a3F19527f9Ba719ea832186cA901f0117150) |
-| QAdmin | [0x5827FfF5F19D1A5C3341f360bA6d6FA0f3b3c801](https://moonbase.moonscan.io/address/0x5827FfF5F19D1A5C3341f360bA6d6FA0f3b3c801) |
-| QPriceOracle | [ 0xcDe78067A71EC2590956811af20dC61375cf5ec3](https://moonbase.moonscan.io/address/0xcDe78067A71EC2590956811af20dC61375cf5ec3) |
-| QollateralManager | [0x4A99eC78c72E9Fb463Efa8C960e708C1632d5e71](https://moonbase.moonscan.io/address/0x4A99eC78c72E9Fb463Efa8C960e708C1632d5e71) |
-| qDEVJUL22 | [0xFb5804db3bbFde798ab5c30eA0321F9A559Ab0Cc](https://moonbase.moonscan.io/address/0xFb5804db3bbFde798ab5c30eA0321F9A559Ab0Cc) |
-| qUSDCJUL22 | [0xAAf53b16EeaD2530d260512d6Bd430b05C76C335](https://moonbase.moonscan.io/addres/0xAAf53b16EeaD2530d260512d6Bd430b05C76C335) |
+| QuotePublisher | [0x7547bDD8e0dD9B6D8aed4c57456eBbDCDBE62CF6](https://moonbase.moonscan.io/address/0x7547bDD8e0dD9B6D8aed4c57456eBbDCDBE62CF6) |
+| QAdmin | [0x2695f3f5c9E8ad3B24526206960Eb9201E23840c](https://moonbase.moonscan.io/address/0x2695f3f5c9E8ad3B24526206960Eb9201E23840c) |
+| QPriceOracle | [0x20f640F350ff0369aB968741dEC6D0F2797CCE0A](https://moonbase.moonscan.io/address/0x20f640F350ff0369aB968741dEC6D0F2797CCE0A) |
+| QollateralManager | [0x8508b8d95c77F11bf38eA394A99DE339708e15d8](https://moonbase.moonscan.io/address/0x8508b8d95c77F11bf38eA394A99DE339708e15d8) |
+| qDEVJUL22 | [0x8b3E2867D882b082C842a5F7aFE6165C78B25FC7](https://moonbase.moonscan.io/address/0x8b3E2867D882b082C842a5F7aFE6165C78B25FC7) |
+| qUSDCJUL22 | [0x25F8CdAAc60fB7fCBb2Bf6BcfA0c1460Fb83f253](https://moonbase.moonscan.io/address/0x25F8CdAAc60fB7fCBb2Bf6BcfA0c1460Fb83f253) |
 
 

--- a/docs/for-developers/QAdmin.md
+++ b/docs/for-developers/QAdmin.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 1
+---
+
+# QAdmin
+
+## Introduction
+
+The QAdmin contract contains meta-information on all supported `Asset`s and available `FixedRateMarket`s for borrowing and lending for each `Asset`. An ERC20 `Asset` on Qoda is (potentially) enabled for two purposes: 
+
+1. For being supplied as collateral. The value of the collateral is determined by its USD value (as determined by on-chain Chainlink oracle), MULTIPLIED by its `collateralFactor` (a value between [0,1]). Generally, large or liquid tokens will have higher `collateralFactor`s while small or illiquid tokens will have lower `collateralFactor`s. A `collateralFactor` of zero implies that the `Asset` is not supported as a collateral token.
+
+2. For creating `FixedRateMarket`s for borrowing and lending the ERC20. The value of borrows of the ERC20 is determined by its USD value (as determined by the on-chain Chainlink oracle), DIVIDED by its `marketFactor` (a value between [0,1]). Generally, large or liquidt tokens will have higher `marketFactor`s while small or illiquid tokens will have lower `marketFactor`s.
+
+## Assets
+
+```
+function assets(address token) external view returns(Asset memory)
+```
+
+Returns the `Asset` data for any given ERC20. An `Asset` is a struct with the following fields:
+
+```
+struct Asset {
+    bool isEnabled;
+    bool isYieldBearing;
+    address underlying;
+    address oracleFeed;
+    uint collateralFactor;
+    uint marketFactor;
+    uint[] maturities;
+}
+```
+
+* `isEnabled` : True if the ERC20 is enabled on Qoda, false otherwise.
+* `isYieldBearing`: Indicates if the `Asset` is a yield-bearing token, for example a Moonwell mToken.
+* `underlying`: The address of the underlying ERC20 token.
+* `oracleFeed`: The corresponding Chainlink oracle address for determining the value of the `Asset`.
+* `collateralFactor`: Used for discounting the value of collateral supplied in the ERC20. Value between [0,1], scaled by 1e8.
+* `marketFactor`: Used for applying a premium on the value of borrows of the ERC20. Value between [0,1], scaled by 1e8.
+* `maturities`: An iterable array of all the enabled maturities (UNIX timestamp in seconds) for the ERC20. An empty array implies there is no available `FixedRateMarket` for borrowing and lending this ERC20.
+
+## FixedRateMarket
+
+```
+function fixedRateMarket(address token, uint maturity) external view returns(address)
+```
+
+Returns the address of the `FixedRateMarket`. A `FixedRateMarket` is a self-contained smart contract that handles all borrowing and lending for a particular market. A `FixedRateMarket` is characterized by two fields:
+
+1. `token`: The underlying ERC20 token that can be borrowed or lent.
+2. `maturity`: The datetime (UNIX timestamp in seconds) after which borrows should be repaid, and when lendings may redeem their underlying. 
+
+Hence, for a particular ERC20, there may be multiple `FixedRateMarket`s corresponding to different `maturity` dates.

--- a/docs/for-developers/QuotePublisher.md
+++ b/docs/for-developers/QuotePublisher.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # QuotePublisher


### PR DESCRIPTION
Some (incomplete) documentation on QAdmin.sol view functions has been added. This is viewable on the "For Developers -> QAdmin" page.

All Moonbase contract addresses have also been updated to replace the old instances which some improperly configured markets.